### PR TITLE
Update GitHub workflow for SIMD optimization testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   build-and-test:
-    name: "Test projects"
-    runs-on: ubuntu-latest
+    name: build-and-test-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+
     steps:
     - name: Install .NET
       uses: actions/setup-dotnet@v4
@@ -21,8 +25,34 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Test Projects (Debug)
-      run: dotnet test -c Debug
+    - name: Build (Debug)
+      run: dotnet build -c Debug
 
-    - name: Test Projects (Release)
-      run: dotnet test -c Release
+    - name: Build (Release)
+      run: dotnet build -c Release
+
+    - name: Test (Debug)
+      run: dotnet test -c Debug --no-build
+
+    - name: Test (Release)
+      run: dotnet test -c Release --no-build
+
+    - name: Test (Debug, AVX2=0)
+      env:
+        DOTNET_EnableAVX2: "0"
+      run: dotnet test -c Debug --no-build
+
+    - name: Test (Release, AVX2=0)
+      env:
+        DOTNET_EnableAVX2: "0"
+      run: dotnet test -c Release --no-build
+
+    - name: Test (Debug, HWIntrinsic=0)
+      env:
+        DOTNET_EnableHWIntrinsic: "0"
+      run: dotnet test -c Debug --no-build
+
+    - name: Test (Release, HWIntrinsic=0)
+      env:
+        DOTNET_EnableHWIntrinsic: "0"
+      run: dotnet test -c Release --no-build

--- a/src/Ramstack.Parsing/Parser.Set.cs
+++ b/src/Ramstack.Parsing/Parser.Set.cs
@@ -624,9 +624,13 @@ partial class Parser
                     }
                     else
                     {
-                        var v = AdvSimd.CompareLessThanOrEqual(
-                            AdvSimd.Subtract(c, x),
-                            y);
+                        // var v = AdvSimd.CompareEqual(
+                        //     AdvSimd.Min(AdvSimd.Max(c, x), y),
+                        //     c);
+
+                        var v = AdvSimd.And(
+                            AdvSimd.CompareGreaterThanOrEqual(c, x),
+                            AdvSimd.CompareLessThanOrEqual(c, y));
 
                         if (!v.Equals(Vector128<ushort>.Zero))
                             return true;

--- a/tests/Ramstack.Parsing.Tests/ParsersTests.Repeat_Opt.cs
+++ b/tests/Ramstack.Parsing.Tests/ParsersTests.Repeat_Opt.cs
@@ -211,7 +211,10 @@ partial class ParsersTests
         var parser = Set(set.ToString()).Many();
         var p = parser.Text();
 
-        Assert.That(parser.GetType().ToString(), Is.EqualTo("Ramstack.Parsing.Parser+RepeatCharClassParser`1[Ramstack.Parsing.Parser+ContainsSearcher]"));
+        Assert.That(parser.GetType().ToString(),
+            Avx2.IsSupported
+                ? Is.EqualTo("Ramstack.Parsing.Parser+RepeatCharClassParser`1[Ramstack.Parsing.Parser+ContainsSearcher]")
+                : Is.EqualTo("Ramstack.Parsing.Parser+RepeatCharClassParser`1[Ramstack.Parsing.Parser+BinaryRangeSearcher]"));
 
         var s = chars.ToString();
         var r = string.Join("", s.Reverse());

--- a/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
+++ b/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
@@ -206,12 +206,12 @@ partial class ParsersTests
 
             if (parser.TryParse(s, out var v))
             {
-                Assert.That(included((char)c), Is.True, $"Char: \\u{c:x4}");
-                Assert.That(v, Is.EqualTo((char)c), $"Char: \\u{c:x4}");
+                Assert.That(included((char)c), Is.True, $"Code: 0x{c:x4}");
+                Assert.That(v, Is.EqualTo((char)c), $"Code: 0x{c:x4}");
             }
             else
             {
-                Assert.That(included((char)c), Is.False, $"Char: \\u{c:x4}");
+                Assert.That(included((char)c), Is.False, $"Code: 0x{c:x4}");
             }
         }
     }

--- a/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
+++ b/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
@@ -122,7 +122,10 @@ partial class ParsersTests
 
         var parser = Set(sb.ToString());
 
-        Assert.That(parser.GetType().ToString(), Is.EqualTo("Ramstack.Parsing.Parser+RangeParser`2[System.Char,Ramstack.Parsing.Parser+ContainsSearcher]"));
+        Assert.That(parser.GetType().ToString(),
+            Avx2.IsSupported
+                ? Is.EqualTo("Ramstack.Parsing.Parser+RangeParser`2[System.Char,Ramstack.Parsing.Parser+ContainsSearcher]")
+                : Is.EqualTo("Ramstack.Parsing.Parser+RangeParser`2[System.Char,Ramstack.Parsing.Parser+BinaryRangeSearcher]"));
         IncludeTest(parser, c => c < 128*5 && c % 5 == 0);
     }
 

--- a/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
+++ b/tests/Ramstack.Parsing.Tests/ParsersTests.Set_Opt.cs
@@ -198,7 +198,7 @@ partial class ParsersTests
         IncludeTest(parser, c => c < 10240 && c % 2 == 0);
     }
 
-    private static void IncludeTest(Parser<char> parser, Func<char, bool> isIncluded)
+    private static void IncludeTest(Parser<char> parser, Func<char, bool> included)
     {
         for (var c = 0; c <= 65535; c++)
         {
@@ -206,12 +206,12 @@ partial class ParsersTests
 
             if (parser.TryParse(s, out var v))
             {
-                Assert.That(isIncluded((char)c), Is.True);
-                Assert.That(v, Is.EqualTo((char)c));
+                Assert.That(included((char)c), Is.True, $"Char: \\u{c:x4}");
+                Assert.That(v, Is.EqualTo((char)c), $"Char: \\u{c:x4}");
             }
             else
             {
-                Assert.That(isIncluded((char)c), Is.False);
+                Assert.That(included((char)c), Is.False, $"Char: \\u{c:x4}");
             }
         }
     }

--- a/tests/Ramstack.Parsing.Tests/Scenarios/JsonTests.cs
+++ b/tests/Ramstack.Parsing.Tests/Scenarios/JsonTests.cs
@@ -10,9 +10,11 @@ public class JsonTests
     [Test]
     public void JsonParseTest()
     {
+        #if NET7_0_OR_GREATER
         var s1 = JsonSerializer.Serialize(JsonParser.Parser.Parse(Json).Value);
         var s2 = JsonSerializer.Serialize(JsonSerializer.Deserialize<object>(Json));
         Assert.That(s1, Is.EqualTo(s2));
+        #endif
     }
 
     private const string Json =

--- a/tests/Ramstack.Parsing.Tests/SimdConfigurationTests.cs
+++ b/tests/Ramstack.Parsing.Tests/SimdConfigurationTests.cs
@@ -1,0 +1,29 @@
+﻿using System.Runtime.InteropServices;
+using System.Runtime.Intrinsics.Arm;
+using System.Runtime.Intrinsics.X86;
+
+namespace Ramstack.Parsing;
+
+[TestFixture]
+public class SimdConfigurationTests
+{
+    [Test]
+    public void VerifySimdConfiguration()
+    {
+        if (Environment.GetEnvironmentVariable("DOTNET_EnableHWIntrinsic") == "0")
+        {
+            Assert.That(Sse2.IsSupported, Is.False);
+            Assert.That(Sse41.IsSupported, Is.False);
+            Assert.That(Avx2.IsSupported, Is.False);
+            Assert.That(AdvSimd.Arm64.IsSupported, Is.False);
+            Assert.That(AdvSimd.IsSupported, Is.False);
+        }
+
+        if (RuntimeInformation.ProcessArchitecture == Architecture.X64 && Environment.GetEnvironmentVariable("DOTNET_EnableAVX2") == "0")
+        {
+            Assert.That(Sse2.IsSupported, Is.True);
+            Assert.That(Sse41.IsSupported, Is.True);
+            Assert.That(Avx2.IsSupported, Is.False);
+        }
+    }
+}


### PR DESCRIPTION
Fix a logic error in ARM64 SIMD range comparison and enhance CI workflow to test SIMD optimizations:

1. **AdvSimd**:
   - Replace the incorrect range check with:
     ```csharp
     AdvSimd.And(
         AdvSimd.CompareGreaterThanOrEqual(c, x),
         AdvSimd.CompareLessThanOrEqual(c, y))
     ```

2. **ARM64 Platform Testing**:
   - Add `ubuntu-24.04-arm` to verify SIMD optimizations work correctly on ARM64 architecture

3. **SIMD Optimization Verification**:
   - Add test cases with `AVX2` explicitly disabled
   - Add test cases with all hardware intrinsics disabled (`HWIntrinsic=0`)

